### PR TITLE
Codecov without global install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
     - node_modules
 install:
   - npm install
-  - npm install -g codecov
 script:
   - npm run build
   - npm test -- --coverage && codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   directories:
     - node_modules
 install:
+  - npm install
   - npm install -g codecov
 script:
   - npm run build

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
+    "codecov": "^3.0.4",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.3.3",


### PR DESCRIPTION
Installs codecov as a dev-dependency node_module instead.

Verified working in travis.yml